### PR TITLE
Update Gatsby minimum to gatsby@2.23.1, fixes #2

### DIFF
--- a/_layouts/package.json
+++ b/_layouts/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "version": "1.0.0",
   "dependencies": {
-    "gatsby": "^2.23.1",
+    "gatsby": "^2.23.18",
     "gatsby-theme-garden": "^0.1.28",
     "react": "^16.3.1",
     "react-dom": "^16.3.1"

--- a/_layouts/package.json
+++ b/_layouts/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "version": "1.0.0",
   "dependencies": {
-    "gatsby": "^2.21.22",
+    "gatsby": "^2.23.1",
     "gatsby-theme-garden": "^0.1.28",
     "react": "^16.3.1",
     "react-dom": "^16.3.1"


### PR DESCRIPTION
Have updated Gatsby as per gatsbyjs/gatsby#25478 
This now builds in GitHub push action
fixes #2 